### PR TITLE
support for SG-1000 expansion memory

### DIFF
--- a/meka/srcs/file.cpp
+++ b/meka/srcs/file.cpp
@@ -662,6 +662,10 @@ void    Load_ROM_Misc (int reset)
         Machine_ON();
     }
 
+#ifdef RETROACHIEVEMENTS
+    RA_UpdateMemoryMap();
+#endif
+
     if (g_machine.driver_id == DRV_SF7000)
         FDC765_Disk_Insert(0, ROM, tsms.Size_ROM);
 

--- a/meka/srcs/retroachievements.h
+++ b/meka/srcs/retroachievements.h
@@ -12,5 +12,6 @@ bool RA_ProcessInputs();
 void RA_EnforceHardcoreRestrictions();
 
 void RA_LoadROM(ConsoleID consoleID);
+void RA_UpdateMemoryMap();
 
 #endif __RETROACHIEVEMENTS_H_


### PR DESCRIPTION
modifies the registered memory regions to match the updated SG-1000 memory map as implemented here: https://github.com/RetroAchievements/rcheevos/pull/116